### PR TITLE
Configure envs for arm64

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,8 @@
 name: Pull-Request Testing
 on:
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -11,22 +13,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
-      - name: Install dependencies
-        run: go mod download
-      - name: Install GolangCI Lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
-
+          go-version-file: 'go.mod'
       - name: golangci-lint
-        run: golangci-lint run --timeout=30m --max-same-issues=0 --out-format=github-actions
-
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.58.2
 
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build docker image
       run: docker build .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,3 +28,15 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build docker image
       run: docker build .
+
+  validate-radixconfig:
+    name: Test RadixConfig
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Fake TOKEN FOR RADIX CLI'
+        run: echo "APP_SERVICE_ACCOUNT_TOKEN=dummy" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+      - name: 'Validate'
+        uses: equinor/radix-github-actions@v1
+        with:
+          args: validate radix-config --config-file radixconfig.yaml

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/equinor/radix-canary-golang
 
-go 1.21
+go 1.22
 
-require github.com/rs/zerolog v1.31.0
+require github.com/rs/zerolog v1.33.0
 
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/rs/xid v1.5.0 // indirect
-	golang.org/x/sys v0.12.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,9 +8,10 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
-github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
+github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -62,13 +62,23 @@ spec:
         requests:
           cpu: 20m
           memory: 20M
+      horizontalScaling:
+        maxReplicas: 1
+        minReplicas: 0
+        triggers:
+          - name: cron
+            cron:
+              timezone: Europe/Oslo
+              start: 0 7 * * 1-5 # 07:00 Monday - Friday
+              end: 0 18 * * 1-5 # 17:00 Monday - Friday
+              desiredReplicas: 1
       environmentConfig:
         - environment: oauthdenyall
           replicas: 1
         - environment: egressrulestopublicdns
-          replicas: 0
+          enabled: false
         - environment: allowradix
-          replicas: 0
+          enabled: false
     - name: web
       readOnlyFileSystem: true
       src: "."
@@ -93,6 +103,16 @@ spec:
         limits:
           cpu: "10m"
           memory: "20M"
+      horizontalScaling:
+        maxReplicas: 1
+        minReplicas: 0
+        triggers:
+          - name: cron
+            cron:
+              timezone: Europe/Oslo
+              start: 0 7 * * 1-5 # 07:00 Monday - Friday
+              end: 0 18 * * 1-5 # 17:00 Monday - Friday
+              desiredReplicas: 1
       environmentConfig:
         - environment: oauthdenyall
           authentication:

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -3,6 +3,8 @@ kind: RadixApplication
 metadata:
   name: radix-networkpolicy-canary
 spec:
+  build:
+    useBuildKit: true
   environments:
     - name: egressrulestopublicdns
       build:
@@ -37,15 +39,29 @@ spec:
       src: ./jobsrc
       schedulerPort: 9000
       timeLimitSeconds: 1
+      runtime:
+        architecture: arm64
+      resources:
+        requests:
+          cpu: "10m"
+          memory: "10M"
+        limits:
+          cpu: "10m"
+          memory: "10M"
   components:
     - name: redis
-      readOnlyFileSystem: true
       src: ./redis
       secrets:
         - REDIS_PASSWORD
       ports:
         - name: redis
           port: 6379
+      runtime:
+        architecture: arm64
+      resources:
+        requests:
+          cpu: 20m
+          memory: 20M
       environmentConfig:
         - environment: oauthdenyall
           replicas: 1
@@ -68,13 +84,15 @@ spec:
         LISTENING_PORT: "5000"
         LOG_LEVEL: "info"
         PRETTY_LOG: "false"
+      runtime:
+        architecture: arm64
       resources:
         requests:
+          cpu: "10m"
           memory: "20M"
-          cpu: "100m"
         limits:
-          memory: "200M"
-          cpu: "1000m"
+          cpu: "10m"
+          memory: "20M"
       environmentConfig:
         - environment: oauthdenyall
           authentication:

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -9,7 +9,6 @@ spec:
     - name: egressrulestopublicdns
       build:
         from: main
-        useBuildKit: true
       egress:
         allowRadix: false
         rules:


### PR DESCRIPTION
- Configure all envs to use arm64
- Configure cron to only run components bwtween 0700 and 1800 on weekdays. Aligned with radix-cicd-canary
- Remove readonlyFileSystem for redis
- Configure resources to be aliged with actual usage