### PR TITLE
Fix runAsNonRoot error

### DIFF
--- a/jobsrc/Dockerfile
+++ b/jobsrc/Dockerfile
@@ -1,2 +1,3 @@
 FROM alpine:latest
-CMD sleep infinity
+USER 65534
+CMD ["sleep", "0"]


### PR DESCRIPTION
run as specific user id
exit immediately (sleep 0) to prevent long lived processes