### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - uses: actions/setup-go@v5
@@ -28,7 +28,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build docker image
       run: docker build .
 
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: 'Fake TOKEN FOR RADIX CLI'
         run: echo "APP_SERVICE_ACCOUNT_TOKEN=dummy" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: equinor/radix-github-actions@v2
       - name: 'Validate'
         run: rx validate radix-config --config-file radixconfig.yaml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,14 +13,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.7.2
 
@@ -28,7 +28,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Build docker image
       run: docker build .
 
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: 'Fake TOKEN FOR RADIX CLI'
         run: echo "APP_SERVICE_ACCOUNT_TOKEN=dummy" >> $GITHUB_ENV
-      - uses: actions/checkout@v6
-      - uses: equinor/radix-github-actions@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: equinor/radix-github-actions@b23674a56b82a1da783b507bc7f15e7ca7067dd8 # v2.0.2
       - name: 'Validate'
         run: rx validate radix-config --config-file radixconfig.yaml


### PR DESCRIPTION
Update deprecated GitHub Actions to versions compatible with Node.js 24.\n\n- Update actions/checkout to v6\n- Update radix-reusable-workflows to v1.1.0\n\nNode.js 20 actions are deprecated and will be forced to run with Node.js 24 by default starting June 2nd, 2026.